### PR TITLE
ISSDEV-1791: Add .bdsignore file

### DIFF
--- a/.bdsignore
+++ b/.bdsignore
@@ -1,0 +1,8 @@
+.*\.bmp
+.*\.dll
+.*\.jpg
+.*\.jpeg
+.*\.gif
+.*\.png
+.*\.so
+.gitignore


### PR DESCRIPTION
Signed-off-by: Nicolas Oliver <dario.n.oliver@intel.com>

The .bdsignore.all file allows us to skip some files from the Protex scans. It use a weird Pattern syntax, the ones listed below are the ones that we know they work for sure :)

It is very important that we do not add more ignore pattern just to solve Protex issues. We should not abuse of this file, otherwise we will be tricking Protex to get us a clean scan, instead of properly assessing our IP Plan correctly. 