### PR TITLE
Add PTSL dependencies

### DIFF
--- a/pstl/convex_hull/sample.json
+++ b/pstl/convex_hull/sample.json
@@ -7,6 +7,6 @@
   "date": "2018-02-26",
   "tag": "system",
   "sample_readme_uri": "https://cdn.rawgit.com/intel-system-studio/samples/$BRANCHNAME/pstl/convex_hull/cpp/readme.html",
-  "dependencies": [ ]
+  "dependencies": ["icc", "tbb"]
 }
 

--- a/pstl/dot_product/sample.json
+++ b/pstl/dot_product/sample.json
@@ -7,6 +7,6 @@
   "date": "2018-03-05",
   "tag": "system",
   "sample_readme_uri": "https://cdn.rawgit.com/intel-system-studio/samples/$BRANCHNAME/pstl/dot_product/cpp/readme.html",
-  "dependencies": [ ]
+  "dependencies": ["icc", "tbb"]
 }
 

--- a/pstl/gamma_correction/sample.json
+++ b/pstl/gamma_correction/sample.json
@@ -7,5 +7,5 @@
   "date": "2018-03-05",
   "tag": "system",
   "sample_readme_uri": "https://cdn.rawgit.com/intel-system-studio/samples/$BRANCHNAME/pstl/gamma_correction/cpp/readme.html",
-  "dependencies": [ ]
+  "dependencies": ["icc", "tbb"]
 }


### PR DESCRIPTION
Samples have a readme.html
that readme takes me to :
https://software.intel.com/en-us/articles/get-started-with-parallel-stl
which says ICC and TBB are dependencies to use PSTL.
Adding those as dependencies to PSTL samples

Signed-off-by: agola <anjali.gola@intel.com>
https://jira.devtools.intel.com/browse/ISS-2998