### PR TITLE
Vtune deprecation notice in ISS 2019 Update 4

### DIFF
--- a/vtune_amplifier/diskio_sample/sample.json
+++ b/vtune_amplifier/diskio_sample/sample.json
@@ -1,8 +1,8 @@
 {
-  "name": "Disk I/O",
+  "name": "Disk I/O [Deprecated]",
   "category": "Intel\u00AE VTune\u2122 Amplifier",
   "categories": [ "Code Samples/Performance, Power, & Thermal Analysis","Tool Samples/Intel\u00AE VTune\u2122 Amplifier" ],
-  "description": "The diskio sample works with the I/O device using the system file cache and user buffer. Use this sample with the Disk Input and Output analysis of the VTune\u2122 Amplifier to analyze such typical performance issues of the I/O bound application as I/O Waits on a user thread and long I/O queues.",
+  "description": "The diskio sample works with the I/O device using the system file cache and user buffer. Use this sample with the Disk Input and Output analysis of the VTune\u2122 Amplifier to analyze such typical performance issues of the I/O bound application as I/O Waits on a user thread and long I/O queues. Deprecation Notice : This sample will be removed from future releases. It will be available on previous release branches on https://github.com/intel-system-studio/samples.",
   "author": "Intel Corporation",
   "date": "2018-03-08",
   "tag": "system",

--- a/vtune_amplifier/jitprofiling_sample/sample.json
+++ b/vtune_amplifier/jitprofiling_sample/sample.json
@@ -1,8 +1,8 @@
 {
-  "name": "JIT Profile",
+  "name": "JIT Profile [Deprecated]",
   "category": "Intel\u00AE VTune\u2122 Amplifier",
   "categories": [ "Code Samples/Performance, Power, & Thermal Analysis","Tool Samples/Intel\u00AE VTune\u2122 Amplifier" ],
-  "description": "The JITprofile sample allows you to explore the capabilities of the JIT Profiling APIs in Intel\u00AE VTune\u2122 Amplifier.",
+  "description": "The JITprofile sample allows you to explore the capabilities of the JIT Profiling APIs in Intel\u00AE VTune\u2122 Amplifier. Deprecation Notice : This sample will be removed from future releases. It will be available on previous release branches on https://github.com/intel-system-studio/samples.",
   "author": "Intel Corporation",
   "date": "2018-03-08",
   "tag": "system",

--- a/vtune_amplifier/linear_regression/sample.json
+++ b/vtune_amplifier/linear_regression/sample.json
@@ -1,8 +1,8 @@
 {
-  "name": "Linear Regression",
+  "name": "Linear Regression [Deprecated]",
   "category": "Intel\u00AE VTune\u2122 Amplifier",
   "categories": [ "Code Samples/Performance, Power, & Thermal Analysis","Tool Samples/Intel\u00AE VTune\u2122 Amplifier" ],
-  "description": "The Linear Regression sample generates the summary statistics of points to give the linear approximation of all of the points.",
+  "description": "The Linear Regression sample generates the summary statistics of points to give the linear approximation of all of the points. Deprecation Notice : This sample will be removed from future releases. It will be available on previous release branches on https://github.com/intel-system-studio/samples.",
   "author": "Intel Corporation",
   "date": "2018-03-08",
   "tag": "system",


### PR DESCRIPTION
1. diskio
2. jitprofiling
3. linear_regression

Signed-off-by: agola <anjali.gola@intel.com>