### PR TITLE
Update cpp.json

### DIFF
--- a/advisor/roofline_demo_samples/cpp/cpp.json
+++ b/advisor/roofline_demo_samples/cpp/cpp.json
@@ -7,7 +7,6 @@
   ],
   "makeVariables": {
     ".DEFAULT_GOAL": "default",
-    "CXXFLAGS": "-parallel",
     "CXX": "${ISS_ROOT}/compilers_and_libraries/linux/bin/intel64/icpc"
   }
 }


### PR DESCRIPTION
The CXX flag property overrides the CXXflags in the makefile. The sample builds without it so removing it. The previous change done to makefile has fixed the sample.